### PR TITLE
feat: LLMモデルの設定を環境変数で制御可能に

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@charcoal-ui/icons": "^2.6.0",
         "@tailwindcss/line-clamp": "^0.4.4",
         "@types/dom-speech-recognition": "^0.0.1",
+        "dotenv": "^16.5.0",
         "eslint": "8.36.0",
         "eslint-config-next": "13.2.4",
         "next": "13.2.4",
@@ -3104,6 +3105,18 @@
       "version": "2.4.5",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.5.tgz",
       "integrity": "sha512-jggCCd+8Iqp4Tsz0nIvpcb22InKEBrGz5dw3EQJMs8HPJDsKbFIO3STYtAvCfDx26Muevn1MHVI0XxjgFfmiSA=="
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/ejs": {
       "version": "3.1.10",
@@ -10085,6 +10098,11 @@
       "version": "2.4.5",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.5.tgz",
       "integrity": "sha512-jggCCd+8Iqp4Tsz0nIvpcb22InKEBrGz5dw3EQJMs8HPJDsKbFIO3STYtAvCfDx26Muevn1MHVI0XxjgFfmiSA=="
+    },
+    "dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg=="
     },
     "ejs": {
       "version": "3.1.10",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@charcoal-ui/icons": "^2.6.0",
     "@tailwindcss/line-clamp": "^0.4.4",
     "@types/dom-speech-recognition": "^0.0.1",
+    "dotenv": "^16.5.0",
     "eslint": "8.36.0",
     "eslint-config-next": "13.2.4",
     "next": "13.2.4",

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -1,7 +1,3 @@
-import React from "react";
-import { IconButton } from "./iconButton";
-import { TextButton } from "./textButton";
-import { Message } from "@/features/messages/messages";
 import {
   KoeiroParam,
   PRESET_A,
@@ -9,7 +5,11 @@ import {
   PRESET_C,
   PRESET_D,
 } from "@/features/constants/koeiroParam";
+import { Message } from "@/features/messages/messages";
+import React from "react";
+import { IconButton } from "./iconButton";
 import { Link } from "./link";
+import { TextButton } from "./textButton";
 
 type Props = {
   openAiKey: string;
@@ -76,7 +76,7 @@ export const Settings = ({
               ChatGPT
               APIはブラウザから直接アクセスしています。また、APIキーや会話内容はピクシブのサーバには保存されません。
               <br />
-              ※利用しているモデルはChatGPT API (GPT-3.5)です。
+              ※利用しているモデルは環境変数NEXT_PUBLIC_LLM_MODELで設定できます。デフォルトはGPT-3.5-turboです。
             </div>
           </div>
           <div className="my-40">

--- a/src/features/chat/manual_tests/openai.test.ts
+++ b/src/features/chat/manual_tests/openai.test.ts
@@ -1,0 +1,54 @@
+import dotenv from 'dotenv';
+import { Message } from "../../messages/messages";
+
+// .envファイルを読み込む
+dotenv.config();
+
+// 環境変数が設定された後にopenAiChatをインポート
+import { getChatResponse, getChatResponseStream } from "../openAiChat";
+
+/**
+ * OpenAI APIの呼び出しをテストするスクリプト
+ * 環境変数NEXT_PUBLIC_LLM_MODELで指定されたモデルを使用して、
+ * getChatResponse関数の動作をテストします。
+ */
+
+describe("Environment variables", () => {
+  it("should load environment variables", () => {
+    console.log("NEXT_PUBLIC_OPEN_AI_KEY:", process.env.NEXT_PUBLIC_OPEN_AI_KEY);
+    console.log("NEXT_PUBLIC_LLM_MODEL:", process.env.NEXT_PUBLIC_LLM_MODEL);
+    expect(process.env.NEXT_PUBLIC_OPEN_AI_KEY).toBeDefined();
+    expect(process.env.NEXT_PUBLIC_LLM_MODEL).toBeDefined();
+  });
+});
+
+describe("OpenAI API", () => {
+  it("should return a response", async () => {
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: "こんにちは",
+      },
+    ];
+
+    const response = await getChatResponse(messages);
+    console.log(response);
+    expect(response.message).toBeDefined();
+  });
+
+  it("should return a stream response", async () => {
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: "こんにちは",
+      },
+    ];
+
+    const response = await getChatResponseStream(messages);
+    console.log(response);
+    expect(response).toBeDefined();
+  });
+});
+
+// 別のモデルでもテスト（オプション）
+// testOpenAiCall(apiKey, "gpt-4"); 

--- a/src/features/chat/openAiChat.ts
+++ b/src/features/chat/openAiChat.ts
@@ -1,7 +1,7 @@
 import { Configuration, OpenAIApi } from "openai";
 import { Message } from "../messages/messages";
 
-const DEFAULT_MODEL = "gpt-3.5-turbo";
+const DEFAULT_MODEL = "gpt-4o-mini";
 const MODEL = process.env.NEXT_PUBLIC_LLM_MODEL || DEFAULT_MODEL;
 const API_KEY = process.env.NEXT_PUBLIC_OPEN_AI_KEY;
 

--- a/src/features/chat/openAiChat.ts
+++ b/src/features/chat/openAiChat.ts
@@ -1,13 +1,17 @@
 import { Configuration, OpenAIApi } from "openai";
 import { Message } from "../messages/messages";
 
-export async function getChatResponse(messages: Message[], apiKey: string) {
-  if (!apiKey) {
-    throw new Error("Invalid API Key");
-  }
+const DEFAULT_MODEL = "gpt-3.5-turbo";
+const MODEL = process.env.NEXT_PUBLIC_LLM_MODEL || DEFAULT_MODEL;
+const API_KEY = process.env.NEXT_PUBLIC_OPEN_AI_KEY;
 
+if (!API_KEY) {
+  throw new Error("NEXT_PUBLIC_OPEN_AI_KEYが設定されていません");
+}
+
+export async function getChatResponse(messages: Message[]) {
   const configuration = new Configuration({
-    apiKey: apiKey,
+    apiKey: API_KEY,
   });
   // ブラウザからAPIを叩くときに発生するエラーを無くすworkaround
   // https://github.com/openai/openai-node/issues/6#issuecomment-1492814621
@@ -16,7 +20,7 @@ export async function getChatResponse(messages: Message[], apiKey: string) {
   const openai = new OpenAIApi(configuration);
 
   const { data } = await openai.createChatCompletion({
-    model: "gpt-3.5-turbo",
+    model: MODEL,
     messages: messages,
   });
 
@@ -26,23 +30,16 @@ export async function getChatResponse(messages: Message[], apiKey: string) {
   return { message: message };
 }
 
-export async function getChatResponseStream(
-  messages: Message[],
-  apiKey: string
-) {
-  if (!apiKey) {
-    throw new Error("Invalid API Key");
-  }
-
+export async function getChatResponseStream(messages: Message[]) {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
+    Authorization: `Bearer ${API_KEY}`,
   };
   const res = await fetch("https://api.openai.com/v1/chat/completions", {
     headers: headers,
     method: "POST",
     body: JSON.stringify({
-      model: "gpt-3.5-turbo",
+      model: MODEL,
       messages: messages,
       stream: true,
       max_tokens: 200,


### PR DESCRIPTION
# LLMモデルの設定を環境変数で制御可能に

## 内容
- 環境変数`NEXT_PUBLIC_LLM_MODEL`で使用するLLMモデルを設定可能に
- OpenAI APIのテストスクリプトを追加
- デフォルトモデルを`gpt-4o-mini`に設定

## 変更点
- `settings.tsx`: モデル設定に関する説明文を更新
- `openAiChat.ts`: 環境変数を使用したAPIキーとモデルの設定を実装
- `openai.test.ts`: OpenAI APIのテストスクリプトを新規追加

## テスト
- 環境変数の読み込みテスト
- OpenAI APIのレスポンステスト
- ストリーミングレスポンスのテスト
