### PR TITLE
パフォーマンス計測機能の追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+memory-bank
 
 # dependencies
 /node_modules

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -79,20 +79,14 @@ export default function Home() {
    */
   const handleSendChat = useCallback(
     async (text: string) => {
-      //if (!openAiKey) {
-      //  setAssistantMessage("APIキーが入力されていません");
-      //  return;
-      //}
-
-      const newMessage = text;
-
-      if (newMessage == null) return;
+      const sendStartTime = performance.now();
+      let isFirstUtterance = true;
 
       setChatProcessing(true);
       // ユーザーの発言を追加して表示
       const messageLog: Message[] = [
         ...chatLog,
-        { role: "user", content: newMessage },
+        { role: "user", content: text },
       ];
       setChatLog(messageLog);
 
@@ -163,6 +157,11 @@ export default function Home() {
             // 文ごとに音声を生成 & 再生、返答を表示
             const currentAssistantMessage = sentences.join(" ");
             handleSpeakAi(aiTalks[0], () => {
+              if (isFirstUtterance) {
+                const timeToFirstUtterance = performance.now() - sendStartTime;
+                console.log(`送信から最初の発話までの時間: ${timeToFirstUtterance.toFixed(2)}ms`);
+                isFirstUtterance = false;
+              }
               setAssistantMessage(currentAssistantMessage);
             });
           }

--- a/src/features/chat/chatClient.ts
+++ b/src/features/chat/chatClient.ts
@@ -32,6 +32,7 @@ export async function getChatResponse(messages: Message[]) {
 }
 
 export async function getChatResponseStream(messages: Message[]) {
+  const startTime = performance.now();
   const response = await fetch("/api/chat", {
     method: "POST",
     headers: {
@@ -71,17 +72,12 @@ export async function getChatResponseStream(messages: Message[]) {
         while (true) {
           const { done, value } = await reader.read();
           if (done) break;
-          const data = decoder.decode(value);
-          const lines = data
-            .split("\n")
-            .filter((line) => line.trim() !== "");
-          for (const line of lines) {
-            const chars = [...line];
-            for (const char of chars) {
-              controller.enqueue(char);
-            }
-          }
+          const token = decoder.decode(value);
+          const timestamp = performance.now() - startTime;
+          console.log(`トークン受信 [${timestamp.toFixed(2)}ms]:`, token);
+          controller.enqueue(token);
         }
+        console.log('ストリーミング完了までの時間:', performance.now() - startTime, 'ms');
       } catch (error) {
         controller.error(error);
       } finally {


### PR DESCRIPTION
# パフォーマンス計測機能の追加

## 変更内容
- チャットAPIのストリーミング処理を改善
- フロントエンドでのパフォーマンス計測機能を追加
- 各種処理時間の計測ポイントを追加
  - ストリーミング開始/完了時間
  - トークン受信時間
  - 最初の発話までの時間

## 期待される効果
- ユーザー体験の向上
- パフォーマンスのボトルネック特定が容易に
